### PR TITLE
Support for placing rollover todos under a tag

### DIFF
--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -17,7 +17,7 @@ export default class RolloverSettingTab extends PluginSettingTab {
     }
 
     const templateContents = await this.app.vault.read(file)
-    const allHeadings = Array.from(templateContents.matchAll(/#{1,} .*/g)).map(([heading]) => heading)
+    const allHeadings = Array.from(templateContents.matchAll(/#{1,}\s?.*/g)).map(([heading]) => heading)
     return allHeadings;
   }
 
@@ -26,8 +26,8 @@ export default class RolloverSettingTab extends PluginSettingTab {
 
     this.containerEl.empty()
     new Setting(this.containerEl)
-      .setName('Template heading')
-      .setDesc('Which heading from your template should the todos go under')
+      .setName('Template heading or tag')
+      .setDesc('Which heading or tag from your template should the todos go under')
       .addDropdown((dropdown) => dropdown
         .addOptions({
           ...templateHeadings.reduce((acc, heading) => {


### PR DESCRIPTION
Currently only `# headers` are support for appending rollover todos. 

This small regex updates allows `#tag` selection as well.