### PR TITLE
Fix accidentally trying to find TODOs in non-Markdown files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export default class RolloverTodosPlugin extends Plugin {
     const { folder, format } = getDailyNoteSettings();
 
     // get all notes in directory that aren't null
-    const dailyNoteFiles = this.app.vault.getAllLoadedFiles()
+    const dailyNoteFiles = this.app.vault.getMarkdownFiles()
       .filter(file => file.path.startsWith(folder))
       .filter(file => file.basename != null)
 


### PR DESCRIPTION
Howdy! 

I stumbled on what seemed like a bug the other day, and I think I've found the right solution. 

### Problem TL;DR

When a `.png` file is "yesterday" (as in the case of `2022-05-31 Tuesday.md`), there are no todos. 

I expected to receive the TODOs from `2022-05-30.md`. Instead, the plugin attempts to read from `Pasted image 20220531134013.png`.  (Shown in screenshots below). 

---

I was running the command the rollover TODOs, and getting zero TODOs. After peeking at the developer console, and checking out which file was being chosen as "yesterday" (`sorted[1]`)  was an image file. 

This is because I have Obisidian set to store pasted/attached assets next to the note file, instead of in a dedicated assets directory. (One of the default available options). 


--- 

### For example, here's some debug code I added: 

![image](https://user-images.githubusercontent.com/575773/171457889-e556f10f-6b3a-4dca-959c-cd955ddb5763.png)

... And the result from the developer console: 

<img width="547" alt="image" src="https://user-images.githubusercontent.com/575773/171458001-b8783821-8f5b-4f67-8079-e842ad73a694.png">

---

And the later code that filters with the `moment` library is *very forgiving*, and does nothing to filter out those binary PNG files. 

### Solution 

To resolve this, I found that the Obsidian API for `vault` has a method called `getMarkdownFiles`. It returns only the Markdown note files from the vault. 

When using that method to retrieve files, I see the expected **sorted** result set, and therefore `sorted[1]` is guaranteed to be a Markdown file. I receive the expected TODOs, in the expected order.  🎉

<img width="545" alt="image" src="https://user-images.githubusercontent.com/575773/171459122-56ffb679-b624-4471-b3dc-7491a5a9cfa4.png">

