### PR TITLE
Support Directories in Daily Note Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Rollover Daily Todos
 
-**This plugin is no longer maintained.** I no longer use it and don't have the time to maintain it. I am happy to transfer ownership to someone else. Just create an issue or discussion and I'll get the transfer done.
-
 This Obsidian plugin will rollover any incomplete todo items from the previous daily note (could be yesterday, or a week ago) to today. This is triggered automatically when a new daily note is created via the internal `Daily notes` plugin, or the `Periodic Notes` plugin., It can also be run as a command from the Command Palette.
 
 ![A demo of the plugin working](./demo.gif)

--- a/src/index.js
+++ b/src/index.js
@@ -71,14 +71,19 @@ export default class RolloverTodosPlugin extends Plugin {
     const todayMoment = moment()
     let dailyNotesTodayOrEarlier = []
     dailyNoteFiles.forEach(file => {
-      if (moment(file.basename, format).isSameOrBefore(todayMoment, 'day')) {
+      if (this.#getFileMoment(file, folder, format).isSameOrBefore(todayMoment, 'day')) {
         dailyNotesTodayOrEarlier.push(file)
       }
     })
 
     // sort by date
-    const sorted = dailyNotesTodayOrEarlier.sort((a, b) => moment(b.basename, format).valueOf() - moment(a.basename, format).valueOf());
+    const sorted = dailyNotesTodayOrEarlier.sort((a, b) => this.#getFileMoment(b, folder, format).valueOf() - this.#getFileMoment(a, folder, format).valueOf());
     return sorted[1];
+  }
+
+  #getFileMoment(file, folder, format) {
+    const path = file.path.replace(`${folder}/`, '').replace(`.${file.extension}`, '')
+    return moment(path, format)
   }
 
   async getAllUnfinishedTodos(file) {
@@ -118,7 +123,7 @@ export default class RolloverTodosPlugin extends Plugin {
     // is today's daily note
     const today = new Date();
     const todayFormatted = window.moment(today).format(format);
-    const filePathConstructed = `${folder}${todayFormatted}.${file.extension}`;
+    const filePathConstructed = `${folder}/${todayFormatted}.${file.extension}`;
     if (filePathConstructed !== file.path) return;
 
     // was just created

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,8 @@ export default class RolloverTodosPlugin extends Plugin {
     // is today's daily note
     const today = new Date();
     const todayFormatted = window.moment(today).format(format);
-    if (todayFormatted !== file.basename) return;
+    const filePathConstructed = `${folder}${todayFormatted}.${file.extension}`;
+    if (filePathConstructed !== file.path) return;
 
     // was just created
     if ((today.getTime() - file.stat.ctime > MAX_TIME_SINCE_CREATION) && !ignoreCreationTime) return;


### PR DESCRIPTION
Taken from #57 which seemed to get dropped during the change of ownership, I noticed a few issues which I've ammended. 

I've tested this locally and it works as expected for me both on a repo with a complex daily note path and a flat daily note path. 

I also tried writing some unit tests but that would require a bigger refactor as the dependency on Obsidian is problematic