### PR TITLE
Roll over todos below a horizontal rule under the template heading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ export default class RolloverTodosPlugin extends Plugin {
       deleteOnComplete: false,
       removeEmptyTodos: false,
       rolloverChildren: false,
+      insertBelowHR: false,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -194,8 +195,8 @@ export default class RolloverTodosPlugin extends Plugin {
         10000
       );
     } else {
-      const { templateHeading, deleteOnComplete, removeEmptyTodos } =
-        this.settings;
+      const { templateHeading, deleteOnComplete, removeEmptyTodos, insertBelowHR } =
+          this.settings;
 
       // check if there is a daily note from yesterday
       const lastDailyNote = this.getLastDailyNote();
@@ -259,10 +260,11 @@ export default class RolloverTodosPlugin extends Plugin {
 
         // If template heading is selected, try to rollover to template heading
         if (templateHeadingSelected) {
-          const contentAddedToHeading = dailyNoteContent.replace(
-            templateHeading,
-            `${templateHeading}${todos_todayString}`
-          );
+          let replacePattern = templateHeading
+          if (insertBelowHR) {
+            replacePattern += "(\n\-\-\-)*"
+          }
+          const contentAddedToHeading = dailyNoteContent.replace(new RegExp(`(${replacePattern})`, "g"), "\$1"+todos_todayString)
           if (contentAddedToHeading == dailyNoteContent) {
             templateHeadingNotFoundMessage = `Rollover couldn't find '${templateHeading}' in today's daily not. Rolling todos to end of file.`;
           } else {

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -93,5 +93,15 @@ export default class RolloverSettingTab extends PluginSettingTab {
             this.plugin.saveSettings();
           })
       );
+      new Setting(this.containerEl)
+          .setName('Insert todos below horizontal rule')
+          .setDesc(`If the heading has a horizontal rule directly below it, then put the rolled-over todos under the rule.`)
+          .addToggle(toggle => toggle
+              .setValue(this.plugin.settings.insertBelowHR || false)
+              .onChange(value => {
+                  this.plugin.settings.insertBelowHR = value;
+                  this.plugin.saveSettings();
+              })
+          );
   }
 }


### PR DESCRIPTION
If a user has a horizontal rule below their template header, then this change will allow the rolled-over todos to be inserted below the horizontal rule.

If the setting is enabled and the template header doesn't have a horizontal rule below it, then the plugin will still roll over the todos as expected.