### PR TITLE
Make Rollover more stable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,17 +76,13 @@ export default class RolloverTodosPlugin extends Plugin {
 
     // remove notes that are from the future
     const todayMoment = moment();
-    let dailyNotesTodayOrEarlier = [];
-    dailyNoteFiles.forEach((file) => {
-      if (
+    const dailyNotesTodayOrEarlier = dailyNoteFiles.filter(
+      (file) =>
         this.getFileMoment(file, folder, format).isSameOrBefore(
           todayMoment,
           "day"
-        )
-      ) {
-        dailyNotesTodayOrEarlier.push(file);
-      }
-    });
+        ) && moment(file.basename, format, true).isValid()
+    );
 
     // sort by date
     const sorted = dailyNotesTodayOrEarlier.sort(


### PR DESCRIPTION
Improving Rollover-logic to take note-title-format into account.

I want to take a stab at https://github.com/lumoe/obsidian-rollover-daily-todos/issues/41 and backed up my current daily note as `_2022-12-09.md`, which threw up the rollover-mechanism.

Nobody should actually have notes other than daily notes in their daily-notes-folder, but if they have, my improvement makes the rollover-mechanism more stable.