### PR TITLE
Make automatic rollover optional (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This Obsidian plugin will rollover any incomplete todo items from the previous d
 
 Just create a new daily note using the `Daily notes` or `Periodic Notes` plugin. The previous day's incomplete todos will be rolled over to today's daily note.
 
+**Note:** Automatic rollover can cause conflicts with other plugins, particularly the Templater plugin. If you're using Templater for your daily notes, it's recommended that you disable automatic rollover in the plugin's settings and instead trigger it manually after creation.
+
 ### 2. Command: Rollover Todos Now
 
 You can also open your command palette (CMD+P on macOS) and start typing `roll` to find this command. No matter where you are in Obsidian, the previous day's todos will get rolled forward. There is also a command called `Undo last rollover` which can be run within 2 minutes of a rollover occurring. Both commands are potentially destructive, and the default text element undo command (CMD+Z on macOS) didn't work. Currently only 1 undo is available for use at the moment.
@@ -29,19 +31,23 @@ Note that if you create a daily note in the future, and you try to run this comm
 
 ## Settings
 
-### 1. Template Heading
+### 1. Disable automatic rollover
+
+If you prefer to trigger the rollover of your todos manually, you can use this setting to prevent the plugin from rolling them over when a new note is created.
+
+### 2. Template Heading
 
 If you chose a template file to use for new daily notes in `Daily notes > Settings` or `Periodic Notes > Settings`, you will be able to choose a heading for incomplete notes to roll into. Note that incomplete todos are taken from the entire file, regardless of what heading they are under. And they are all rolled into today's daily note, right under the heading of choice.
 
 If you leave this field as blank, or select `None`, then incomplete todos will be rolled onto the end of today's note (for new notes with no template, the end is the beginning of the note).
 
-### 2. Delete todos from previous day
+### 3. Delete todos from previous day
 
 By default, this plugin will actually make a copy of incomplete todos. So if you forgot to wash your dog yesterday, and didn't check it off, then you will have an incomplete checkmark on yesterday's daily note, and a new incomplete checkmark will be rolled into today's daily note. If you use the `Undo last rollover` command, deleted todos will be restored (remember, the `time limit on this is 2 minutes`).
 
 Toggling this setting on will remove incomplete todos from the previous daily note once today's daily note has a copy of them.
 
-### 3. Remove empty todos in rollover
+### 4. Remove empty todos in rollover
 
 By default, this plugin will roll over anything that has a checkbox, whether it has content or not. Toggling this setting on will ignore empty todos. If you have **#2** from above toggled on, it will also delete empty todos.
 
@@ -71,6 +77,8 @@ And the previous day might look like
 
 - [x] Do the dishes
 ```
+
+3. There are sometimes conflicts with other plugins that deal with new notes -- particularly the Templater plugin. In these situations, your todos may be removed from your previous note, and then not be saved into your new daily note. The simplest remedy is to disable the automatic rollover, and instead trigger it manually.
 
 ## Installation
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default class RolloverTodosPlugin extends Plugin {
   async loadSettings() {
     const DEFAULT_SETTINGS = {
       templateHeading: "none",
+      automaticallyRollover: true,
       deleteOnComplete: false,
       removeEmptyTodos: false,
       rolloverChildren: false,
@@ -154,7 +155,10 @@ export default class RolloverTodosPlugin extends Plugin {
     return folder;
   }
 
-  async rollover(file = undefined) {
+  async rollover(file = undefined, manual = false) {
+    // If we don't automatically rollover, we abort processing -- unless we've explicitly requested a rollover
+    if (!manual && !this.settings.automaticallyRollover) return;
+
     /*** First we check if the file created is actually a valid daily note ***/
     let { folder, format } = getDailyNoteSettings();
     let ignoreCreationTime = false;
@@ -350,7 +354,7 @@ export default class RolloverTodosPlugin extends Plugin {
 
     this.registerEvent(
       this.app.vault.on("create", async (file) => {
-        this.rollover(file);
+        this.rollover(file, false);
       })
     );
 
@@ -358,7 +362,7 @@ export default class RolloverTodosPlugin extends Plugin {
       id: "obsidian-rollover-daily-todos-rollover",
       name: "Rollover Todos Now",
       callback: () => {
-        this.rollover();
+        this.rollover(undefined, true);
       },
     });
 

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -34,6 +34,18 @@ export default class RolloverSettingTab extends PluginSettingTab {
 
     this.containerEl.empty();
     new Setting(this.containerEl)
+      .setName("Automatically rollover")
+      .setDesc("Rollover todos when today's dialy note is created automatically")
+      .addToggle((toggle) => 
+        toggle
+          .setValue(this.plugin.settings.automaticallyRollover || false)
+          .onChange((value) => {
+            this.plugin.settings.automaticallyRollover = value;
+            this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(this.containerEl)
       .setName("Template heading")
       .setDesc("Which heading from your template should the todos go under")
       .addDropdown((dropdown) =>


### PR DESCRIPTION
This adds a new option to control whether or not the rollover happens automatically upon file creation, or whether it must be manually triggered. This will resolve #103, and should make this plugin easier to use in conjunction with Templater.