### PR TITLE
Add setting for automatic rollover

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This Obsidian plugin will rollover any incomplete todo items from the previous d
 
 Just create a new daily note using the `Daily notes` or `Periodic Notes` plugin. The previous day's incomplete todos will be rolled over to today's daily note.
 
-### 2. Command: Rollover Todos Now
+**Note:** Automatic rollover can cause conflicts with other plugins, particularly the Templater plugin. If you're using Templater for your daily notes, it's recommended that you disable automatic rollover in the plugin's settings and instead trigger it manually after creation.
+
+### 2. Command: Manual Rollover Todos Now
 
 You can also open your command palette (CMD+P on macOS) and start typing `roll` to find this command. No matter where you are in Obsidian, the previous day's todos will get rolled forward. There is also a command called `Undo last rollover` which can be run within 2 minutes of a rollover occurring. Both commands are potentially destructive, and the default text element undo command (CMD+Z on macOS) didn't work. Currently only 1 undo is available for use at the moment.
 
@@ -29,19 +31,23 @@ Note that if you create a daily note in the future, and you try to run this comm
 
 ## Settings
 
-### 1. Template Heading
+### 1. Disable automatic rollover
+
+If you prefer to trigger the rollover of your todos manually, you can use this setting to prevent the plugin from rolling them over when a new note is created.
+
+### 2. Template Heading
 
 If you chose a template file to use for new daily notes in `Daily notes > Settings` or `Periodic Notes > Settings`, you will be able to choose a heading for incomplete notes to roll into. Note that incomplete todos are taken from the entire file, regardless of what heading they are under. And they are all rolled into today's daily note, right under the heading of choice.
 
 If you leave this field as blank, or select `None`, then incomplete todos will be rolled onto the end of today's note (for new notes with no template, the end is the beginning of the note).
 
-### 2. Delete todos from previous day
+### 3. Delete todos from previous day
 
 By default, this plugin will actually make a copy of incomplete todos. So if you forgot to wash your dog yesterday, and didn't check it off, then you will have an incomplete checkmark on yesterday's daily note, and a new incomplete checkmark will be rolled into today's daily note. If you use the `Undo last rollover` command, deleted todos will be restored (remember, the `time limit on this is 2 minutes`).
 
 Toggling this setting on will remove incomplete todos from the previous daily note once today's daily note has a copy of them.
 
-### 3. Remove empty todos in rollover
+### 4. Remove empty todos in rollover
 
 By default, this plugin will roll over anything that has a checkbox, whether it has content or not. Toggling this setting on will ignore empty todos. If you have **#2** from above toggled on, it will also delete empty todos.
 
@@ -71,6 +77,8 @@ And the previous day might look like
 
 - [x] Do the dishes
 ```
+
+3. There are sometimes conflicts with other plugins that deal with new notes -- particularly the Templater plugin. In these situations, your todos may be removed from your previous note, and then not be saved into your new daily note. The simplest remedy is to disable the automatic rollover, and instead trigger it manually.
 
 ## Installation
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ export default class RolloverTodosPlugin extends Plugin {
       deleteOnComplete: false,
       removeEmptyTodos: false,
       rolloverChildren: false,
+      rolloverOnFileCreate: true,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -350,6 +351,8 @@ export default class RolloverTodosPlugin extends Plugin {
 
     this.registerEvent(
       this.app.vault.on("create", async (file) => {
+        // Check if automatic daily note creation is enabled
+        if (!this.settings.rolloverOnFileCreate) return;
         this.rollover(file);
       })
     );

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -93,5 +93,27 @@ export default class RolloverSettingTab extends PluginSettingTab {
             this.plugin.saveSettings();
           })
       );
+
+    new Setting(this.containerEl)
+      .setName("Automatic rollover on daily note open")
+      .setDesc(
+        `If enabled, the plugin will automatically rollover todos when you open a daily note.`
+      )
+      .addToggle((toggle) =>
+        toggle
+          // Default to true if the setting is not set
+          .setValue(
+            this.plugin.settings.rolloverOnFileCreate === undefined ||
+              this.plugin.settings.rolloverOnFileCreate === null
+              ? true
+              : this.plugin.settings.rolloverOnFileCreate
+          )
+          .onChange((value) => {
+            console.log(value);
+            this.plugin.settings.rolloverOnFileCreate = value;
+            this.plugin.saveSettings();
+            this.plugin.loadData().then((value) => console.log(value));
+          })
+      );
   }
 }


### PR DESCRIPTION
As a workaround to mitigate the race condition introduced by the Templater plugin, I would suggest the possibility to disable the automatic rollover on file creation. This should fix the problem for most of the people in #105 

What do you think @tim-hilt?