### PR TITLE
Support all bullet symbols as per MD spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ By default, this plugin will roll over anything that has a checkbox, whether it 
 
 1. Sometimes you will use this plugin, and your unfinished todos will stay in the same spot. These could be formatting issues.
 
-- Regex is used to search for unfinished todos: `/\t*- \[ \].*/g`
+- Regex is used to search for unfinished todos: `/\s*[-*+] \[ \].*/g`
 - At a minimum, they need to look like: `start of line | tabs`-` `[` `]`Your text goes here`
 - If you use spaces instead of tabs at the start of the line, the behavior of the plugin can be inconsistent. Sometimes it'll roll items over, but not delete them from the previous day when you have that option toggled on.
 

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -1,4 +1,7 @@
 class TodoParser {
+  // Support all unordered list bullet symbols as per spec (https://daringfireball.net/projects/markdown/syntax#list)
+  bulletSymbols = ["-", "*", "+"];
+
   // List of strings that include the Markdown content
   #lines;
 
@@ -12,7 +15,7 @@ class TodoParser {
 
   // Returns true if string s is a todo-item
   #isTodo(s) {
-    const r = /\s*- \[ \].*/g;
+    const r = new RegExp(`\\s*[${this.bulletSymbols.join("")}] \\[ \\].*`, "g"); // /\s*[-*+] \[ \].*/g;
     return r.test(s);
   }
 

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -40,6 +40,33 @@ test("get todos with children", function () {
   expect(todos).toStrictEqual(result);
 });
 
+test("get todos (with alternate symbols) with children", function () {
+  // GIVEN
+  const lines = [
+    "+ [ ] TODO",
+    "    + [ ] Next",
+    "    * some stuff",
+    "* [ ] Another one",
+    "    - [ ] More children",
+    "    + another child",
+    "- this isn't copied",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines: lines, withChildren: true });
+
+  // THEN
+  const result = [
+    "+ [ ] TODO",
+    "    + [ ] Next",
+    "    * some stuff",
+    "* [ ] Another one",
+    "    - [ ] More children",
+    "    + another child",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
 test("get todos without children", () => {
   // GIVEN
   const lines = [


### PR DESCRIPTION
Adds support for all bullet symbols allowed as per [Markdown spec](https://daringfireball.net/projects/markdown/syntax#list). Also updates the regex in README to match the one in code.