### PR TITLE
Add various optional functionality

### DIFF
--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -114,9 +114,6 @@ class TodoParser {
             if (!this.#withCompletedChildren && this.#isCompletedTodo(c)) {
               return false;
             }
-            if (this.#isCompletedTodo(c)) {
-              return true;
-            }
             return (!this.#filterChildren || this.isRelevant(c));
           });
           todos = [...todos, ...cs];

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -1,6 +1,6 @@
 class TodoParser {
   // Support all unordered list bullet symbols as per spec (https://daringfireball.net/projects/markdown/syntax#list)
-  bulletSymbols = ["-", "*", "+"];
+  bulletSymbols = ["-", "*", "+", "#"];
 
   // List of strings that include the Markdown content
   #lines;

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -8,8 +8,8 @@ class TodoParser {
   // Boolean that encodes whether nested items should be rolled over
   #withChildren;
 
-  // Boolean that encodes whether sub-headings of nested items should be rolled over. Only relevant when #withChildren is true.
-  #withSubheadings;
+  // Boolean that encodes whether headings should be rolled over.
+  #withHeadings;
 
   // Boolean that encodes whether bullets should be rolled over.
   #withBullets;
@@ -20,10 +20,10 @@ class TodoParser {
   // Boolean that encodes whether completed children should be rolled over. Only relevant when #withChildren is true and #filterChildren is true.
   #withCompletedChildren;
 
-  constructor(lines, withChildren, withSubheadings, withBullets, filterChildren, withCompletedChildren) {
+  constructor(lines, withChildren, withHeadings, withBullets, filterChildren, withCompletedChildren) {
     this.#lines = lines;
     this.#withChildren = withChildren;
-    this.#withSubheadings = withChildren && withSubheadings;
+    this.#withHeadings = withHeadings;
     this.#withBullets = withBullets;
     this.#filterChildren = filterChildren;
     this.#withCompletedChildren = withCompletedChildren;
@@ -95,11 +95,15 @@ class TodoParser {
       return true;
     }
 
+    if (this.#withHeadings && this.#isHeading(line)) {
+      return true;
+    }
+
     if (this.#withBullets) {
       return this.#isBullet(line);
     }
 
-    return this.#withSubheadings && this.#isHeading(line);
+    return false;
   }
 
   // Returns a list of strings that represents all the todos along with there potential children
@@ -107,7 +111,7 @@ class TodoParser {
     let todos = [];
     for (let l = 0; l < this.#lines.length; l++) {
       const line = this.#lines[l];
-      if (this.#isTodo(line) || (l !== 0 && this.#withSubheadings && this.#isHeading(line)) || (this.#withBullets && this.#isBullet(line))) {
+      if (this.isRelevant(line)) {
         todos.push(line);
         if (this.#withChildren && this.#hasChildren(l)) {
           const cs = this.#getChildren(l).filter(c => {
@@ -126,7 +130,7 @@ class TodoParser {
 }
 
 // Utility-function that acts as a thin wrapper around `TodoParser`
-export const getTodos = ({ lines, withChildren = false , withSubHeadings = false, withBullets = false, filterChildren = false, withCompletedChildren = true}) => {
-  const todoParser = new TodoParser(lines, withChildren, withSubHeadings, withBullets, filterChildren, withCompletedChildren);
+export const getTodos = ({ lines, withChildren = false , withHeadings = false, withBullets = false, filterChildren = false, withCompletedChildren = true}) => {
+  const todoParser = new TodoParser(lines, withChildren, withHeadings, withBullets, filterChildren, withCompletedChildren);
   return todoParser.getTodos();
 };

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -1,6 +1,6 @@
 class TodoParser {
   // Support all unordered list bullet symbols as per spec (https://daringfireball.net/projects/markdown/syntax#list)
-  bulletSymbols = ["-", "*", "+", "#"];
+  bulletSymbols = ["-", "*", "+"];
 
   // List of strings that include the Markdown content
   #lines;
@@ -8,15 +8,25 @@ class TodoParser {
   // Boolean that encodes whether nested items should be rolled over
   #withChildren;
 
-  constructor(lines, withChildren) {
+  // Boolean that encodes whether sub-headings of nested items should be rolled over. Only relevant when #withChildren is true.
+  #withSubheadings;
+
+  constructor(lines, withChildren, withSubheadings) {
     this.#lines = lines;
     this.#withChildren = withChildren;
+    this.#withSubheadings = withChildren && withSubheadings;
   }
 
   // Returns true if string s is a todo-item
   #isTodo(s) {
-    const r = new RegExp(`\\s*[${this.bulletSymbols.join("")}] \\[[^xX-]\\].*`, "g"); // /\s*[-*+] \[[^xX-]\].*/g;
+    const r = new RegExp(`\\s*[${this.bulletSymbols.join("")}] \\[[^xX-]].*`, "g"); // /\s*[-*+] \[[^xX-]\].*/g;
     return r.test(s);
+  }
+
+  // Returns true if the string is a heading
+  #isHeading(s) {
+    const h = new RegExp(`\\s*#+.*`, "g");
+    return h.test(s);
   }
 
   // Returns true if line after line-number `l` is a nested item
@@ -56,15 +66,22 @@ class TodoParser {
     return this.#lines[l].search(/\S/);
   }
 
+  isRelevant(line) {
+    if (this.#isTodo(line)) {
+      return true;
+    }
+    return this.#withSubheadings && this.#isHeading(line);
+  }
+
   // Returns a list of strings that represents all the todos along with there potential children
   getTodos() {
     let todos = [];
     for (let l = 0; l < this.#lines.length; l++) {
       const line = this.#lines[l];
-      if (this.#isTodo(line)) {
+      if (this.#isTodo(line) || (l !== 0 && this.#withSubheadings && this.#isHeading(line))) {
         todos.push(line);
         if (this.#withChildren && this.#hasChildren(l)) {
-          const cs = this.#getChildren(l);
+          const cs = this.#getChildren(l).filter(c => this.isRelevant(c));
           todos = [...todos, ...cs];
           l += cs.length;
         }
@@ -75,7 +92,7 @@ class TodoParser {
 }
 
 // Utility-function that acts as a thin wrapper around `TodoParser`
-export const getTodos = ({ lines, withChildren = false }) => {
-  const todoParser = new TodoParser(lines, withChildren);
+export const getTodos = ({ lines, withChildren = false , withSubHeadings = false}) => {
+  const todoParser = new TodoParser(lines, withChildren, withSubHeadings);
   return todoParser.getTodos();
 };

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -357,7 +357,7 @@ test("get todos doesn't add intermediate other elements", () => {
   expect(todos).toStrictEqual(result);
 });
 
-test("get todos doesn't adds subheadings", () => {
+test("get todos doesn't add headings", () => {
   // GIVEN
   const lines = [
     "# Some title",
@@ -380,10 +380,11 @@ test("get todos doesn't adds subheadings", () => {
   ];
 
   // WHEN
-  const todos = getTodos({ lines, withChildren: true, withBullets: false, filterChildren: true, withSubHeadings: true});
+  const todos = getTodos({ lines, withChildren: true, withBullets: false, filterChildren: true, withHeadings: true});
 
   // THEN
   const result = [
+    "# Some title",
     "- [ ] TODO",
     "    - [ ] Next",
     "## Some title",
@@ -393,7 +394,7 @@ test("get todos doesn't adds subheadings", () => {
   expect(todos).toStrictEqual(result);
 });
 
-test("get todos doesn't adds subheadings and sub bullets", () => {
+test("get todos doesn't add headings and sub bullets", () => {
   // GIVEN
   const lines = [
     "# Some title",
@@ -416,10 +417,11 @@ test("get todos doesn't adds subheadings and sub bullets", () => {
   ];
 
   // WHEN
-  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: true, withSubHeadings: true});
+  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: true, withHeadings: true});
 
   // THEN
   const result = [
+    "# Some title",
     "- [ ] TODO",
     "    - [ ] Next",
     "    - some stuff",
@@ -457,10 +459,11 @@ test("get todos includes bullets", () => {
   ];
 
   // WHEN
-  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: false, withSubHeadings: true});
+  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: false, withHeadings: true});
 
   // THEN
   const result = [
+    "# Some title",
     "- bullet",
     "- [ ] TODO",
     "    - [ ] Next",

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -128,6 +128,30 @@ test("get todos (with alternate symbols and partially checked todos) with childr
   expect(todos).toStrictEqual(result);
 });
 
+test("get todos (with alternate symbols and partially checked todos) with children without completed children", function () {
+  // GIVEN
+  const lines = [
+    "+ [x] Completed TODO",
+    "    + [ ] Next",
+    "    * some stuff",
+    "* [ ] Another one",
+    "    - [x] Completed child",
+    "    + another child",
+    "- this isn't copied",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines: lines, withChildren: true, withCompletedChildren: false});
+
+  // THEN
+  const result = [
+    "    + [ ] Next",
+    "* [ ] Another one",
+    "    + another child",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
 test("get todos (with default dash prefix and finished todos) with children", function () {
   // GIVEN
   const lines = [
@@ -199,6 +223,7 @@ test("get todos with correct alternate checkbox children", function () {
   const result = [
     "- [ ] TODO",
     "    - [ ] Next",
+    "    - [x] Completed task",
     "    - some stuff",
     "- [ ] Another one",
     "    - [ ] Another child",
@@ -207,6 +232,38 @@ test("get todos with correct alternate checkbox children", function () {
   ];
   expect(todos).toStrictEqual(result);
 });
+
+test("get todos with correct alternate checkbox children without finished subtasks", function () {
+  // GIVEN
+  const lines = [
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - [x] Completed task",
+    "    - some stuff",
+    "- [ ] Another one",
+    "    - [ ] Another child",
+    "    - [/] More children",
+    "    - [x] Completed children",
+    "    - another child",
+    "- this isn't copied",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines: lines, withChildren: true, withCompletedChildren: false});
+
+  // THEN
+  const result = [
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "- [ ] Another one",
+    "    - [ ] Another child",
+    "    - [/] More children",
+    "    - another child",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
 test("get todos with children doesn't fail if child at end of list", () => {
   // GIVEN
   const lines = [
@@ -300,7 +357,7 @@ test("get todos doesn't add intermediate other elements", () => {
   expect(todos).toStrictEqual(result);
 });
 
-test("get todos adds sub headings when enabled", () => {
+test("get todos doesn't adds subheadings", () => {
   // GIVEN
   const lines = [
     "# Some title",
@@ -309,7 +366,7 @@ test("get todos adds sub headings when enabled", () => {
     "    - [ ] Next",
     "    - some stuff",
     "",
-    "## Some sub title",
+    "## Some title",
     "",
     "Some text",
     "...that continues here",
@@ -323,14 +380,94 @@ test("get todos adds sub headings when enabled", () => {
   ];
 
   // WHEN
-  const todos = getTodos({ lines, withChildren: true , withSubHeadings: true});
+  const todos = getTodos({ lines, withChildren: true, withBullets: false, filterChildren: true, withSubHeadings: true});
+
+  // THEN
+  const result = [
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "## Some title",
+    "- [ ] Another one",
+    "    - [ ] More children",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
+test("get todos doesn't adds subheadings and sub bullets", () => {
+  // GIVEN
+  const lines = [
+    "# Some title",
+    "",
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "",
+    "## Some title",
+    "",
+    "Some text",
+    "...that continues here",
+    "",
+    "- Here is a bullet item that is a valid child",
+    "- Here is another bullet item",
+    "1. Here is a numbered list item",
+    "- [ ] Another one",
+    "    - [ ] More children",
+    "    - another child",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: true, withSubHeadings: true});
 
   // THEN
   const result = [
     "- [ ] TODO",
     "    - [ ] Next",
     "    - some stuff",
-    "## Some sub title",
+    "## Some title",
+    "- Here is a bullet item that is a valid child",
+    "- Here is another bullet item",
+    "- [ ] Another one",
+    "    - [ ] More children",
+    "    - another child",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
+test("get todos includes bullets", () => {
+  // GIVEN
+  const lines = [
+    "# Some title",
+    "",
+    "- bullet",
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "",
+    "## Some title",
+    "",
+    "Some text",
+    "...that continues here",
+    "",
+    "- Here is a bullet item that is a valid child",
+    "- Here is another bullet item",
+    "1. Here is a numbered list item",
+    "- [ ] Another one",
+    "    - [ ] More children",
+    "    - another child",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines, withChildren: true, withBullets: true, filterChildren: false, withSubHeadings: true});
+
+  // THEN
+  const result = [
+    "- bullet",
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "## Some title",
+    "- Here is a bullet item that is a valid child",
+    "- Here is another bullet item",
     "- [ ] Another one",
     "    - [ ] More children",
     "    - another child",

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -33,7 +33,7 @@ test("single done todo element should not return itself", () => {
   const result = getTodos({ lines });
 
   // THEN
-  const todos = [""];
+  const todos = [];
   expect(result).toStrictEqual(todos);
 });
 
@@ -45,7 +45,7 @@ test("single canceled todo element should not return itself", () => {
   const result = getTodos({ lines });
 
   // THEN
-  const todos = [""];
+  const todos = [];
   expect(result).toStrictEqual(todos);
 });
 
@@ -293,6 +293,44 @@ test("get todos doesn't add intermediate other elements", () => {
     "- [ ] TODO",
     "    - [ ] Next",
     "    - some stuff",
+    "- [ ] Another one",
+    "    - [ ] More children",
+    "    - another child",
+  ];
+  expect(todos).toStrictEqual(result);
+});
+
+test("get todos adds sub headings when enabled", () => {
+  // GIVEN
+  const lines = [
+    "# Some title",
+    "",
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "",
+    "## Some sub title",
+    "",
+    "Some text",
+    "...that continues here",
+    "",
+    "- Here is a bullet item",
+    "- Here is another bullet item",
+    "1. Here is a numbered list item",
+    "- [ ] Another one",
+    "    - [ ] More children",
+    "    - another child",
+  ];
+
+  // WHEN
+  const todos = getTodos({ lines, withChildren: true , withSubHeadings: true});
+
+  // THEN
+  const result = [
+    "- [ ] TODO",
+    "    - [ ] Next",
+    "    - some stuff",
+    "## Some sub title",
     "- [ ] Another one",
     "    - [ ] More children",
     "    - another child",

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ export default class RolloverTodosPlugin extends Plugin {
       removeEmptyTodos: false,
       rolloverChildren: false,
       rolloverOnFileCreate: true,
+      rolloverSubheadings: false,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -126,6 +127,7 @@ export default class RolloverTodosPlugin extends Plugin {
     return getTodos({
       lines: dnLines,
       withChildren: this.settings.rolloverChildren,
+      withSubHeadings: this.settings.rolloverSubheadings,
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,9 @@ export default class RolloverTodosPlugin extends Plugin {
       rolloverChildren: false,
       rolloverOnFileCreate: true,
       rolloverSubheadings: false,
+      rolloverBullets: false,
+      filterChildren: false,
+      rolloverCompletedChildren: true,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -128,6 +131,9 @@ export default class RolloverTodosPlugin extends Plugin {
       lines: dnLines,
       withChildren: this.settings.rolloverChildren,
       withSubHeadings: this.settings.rolloverSubheadings,
+      withBullets: this.settings.rolloverBullets,
+      filterChildren: this.settings.filterChildren,
+      withCompletedChildren: this.settings.rolloverCompletedChildren,
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export default class RolloverTodosPlugin extends Plugin {
       removeEmptyTodos: false,
       rolloverChildren: false,
       rolloverOnFileCreate: true,
-      rolloverSubheadings: false,
+      rolloverHeadings: false,
       rolloverBullets: false,
       filterChildren: false,
       rolloverCompletedChildren: true,
@@ -130,7 +130,7 @@ export default class RolloverTodosPlugin extends Plugin {
     return getTodos({
       lines: dnLines,
       withChildren: this.settings.rolloverChildren,
-      withSubHeadings: this.settings.rolloverSubheadings,
+      withHeadings: this.settings.rolloverHeadings,
       withBullets: this.settings.rolloverBullets,
       filterChildren: this.settings.filterChildren,
       withCompletedChildren: this.settings.rolloverCompletedChildren,


### PR DESCRIPTION
&check; Add toggle to include headings (defaults to off) in rollover- this is useful for my personal workflow. Right now items under heads are carried over, but the headings themselves are not.
&check; Add toggle to include bulleted items in rollover. Current behavior is that bulleted items (and sub items) of a TODO are carried over, but not top-level bullets.
&check; Add toggle to not roll over completed sub-todos
&check; Add toggle to filter child items of todos. Right now all are included. Respects above settings to check for headers and bullets.
&check; Added some tests around these scenarios
&check; Fixed existing broken tests.

Please let me know if this is something you'd consider merging, or if there's additional testing / other strategies for approaching these additions.