### PR TITLE
feat: copy notes into system clipboard in between rollover

### DIFF
--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -129,5 +129,19 @@ export default class RolloverSettingTab extends PluginSettingTab {
             this.plugin.saveSettings();
           })
       );
+
+    new Setting(this.containerEl)
+      .setName("Copy todos to clipboard for safety")
+      .setDesc(
+        `When enabled, todos are automatically copied to the system clipboard before deletion. This provides a safety backup in case file operations fail, preventing todo loss.`
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.clipboardSafety !== false) // Default to true
+          .onChange((value) => {
+            this.plugin.settings.clipboardSafety = value;
+            this.plugin.saveSettings();
+          })
+      );
   }
 }


### PR DESCRIPTION
Since we have to delete TODOs first and insert them afterwards, this plugin should offer a default fallback that's enabled per default. This commit implements this fallback by copying notes into system clipboard between operations. The behavior can be turned off in the settings.

The issue fixed here happened to me a couple of days ago when the daily note file somehow was read-only on startup, causing my todos of months to be lost. I did not know that "Undo rollover" exists and to be honest, it should not be a command option but rather a default behavior like copying to clipboard. 

This PR prevents e.g. #162 