### PR TITLE
feat: Add option to ignore todos in blockquotes/callouts

### DIFF
--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -11,6 +11,9 @@ class TodoParser {
   // Boolean that encodes whether nested items should be rolled over
   #withChildren;
 
+  // Boolean that encodes whether todos in blockquotes/callouts should be ignored
+  #ignoreBlockquotes;
+
   // Parse content with segmentation to allow for Unicode grapheme clusters
   #parseIntoChars(content, contentType = "content") {
     // Use Intl.Segmenter to properly split grapheme clusters if available,
@@ -29,9 +32,10 @@ class TodoParser {
     }
   }
 
-  constructor(lines, withChildren, doneStatusMarkers) {
+  constructor(lines, withChildren, doneStatusMarkers, ignoreBlockquotes) {
     this.#lines = lines;
     this.#withChildren = withChildren;
+    this.#ignoreBlockquotes = ignoreBlockquotes || false;
     if (doneStatusMarkers) {
       this.doneStatusMarkers = this.#parseIntoChars(
         doneStatusMarkers,
@@ -116,12 +120,20 @@ class TodoParser {
     return this.#lines[l].search(/\S/);
   }
 
+  // Returns true if string s is inside a blockquote (starts with >)
+  // This is used to ignore todos inside callouts/blockquotes
+  #isInBlockquote(s) {
+    return /^\s*>/.test(s);
+  }
+
   // Returns a list of strings that represents all the todos along with there potential children
   getTodos() {
     let todos = [];
     for (let l = 0; l < this.#lines.length; l++) {
       const line = this.#lines[l];
-      if (this.#isTodo(line)) {
+      // Skip todos that are inside blockquotes/callouts (if setting is enabled)
+      const shouldSkipBlockquote = this.#ignoreBlockquotes && this.#isInBlockquote(line);
+      if (this.#isTodo(line) && !shouldSkipBlockquote) {
         todos.push(line);
         if (this.#withChildren && this.#hasChildren(l)) {
           const cs = this.#getChildren(l);
@@ -139,7 +151,8 @@ export const getTodos = ({
   lines,
   withChildren = false,
   doneStatusMarkers = null,
+  ignoreBlockquotes = false,
 }) => {
-  const todoParser = new TodoParser(lines, withChildren, doneStatusMarkers);
+  const todoParser = new TodoParser(lines, withChildren, doneStatusMarkers, ignoreBlockquotes);
   return todoParser.getTodos();
 };

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export default class RolloverTodosPlugin extends Plugin {
       rolloverOnFileCreate: true,
       doneStatusMarkers: "xX-",
       leadingNewLine: true,
+      ignoreBlockquotes: false,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -129,6 +130,7 @@ export default class RolloverTodosPlugin extends Plugin {
       lines: dnLines,
       withChildren: this.settings.rolloverChildren,
       doneStatusMarkers: this.settings.doneStatusMarkers,
+      ignoreBlockquotes: this.settings.ignoreBlockquotes,
     });
   }
 

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -132,17 +132,31 @@ export default class RolloverSettingTab extends PluginSettingTab {
     new Setting(this.containerEl)
       .setName("Add extra blank line between Heading and Todos")
       .setDesc(`Whether to add an extra blank line between the selected Heading and the rolled over todos. This will only work in combination with a configured Template Heading.`)
-      .addToggle((toggle) => 
+      .addToggle((toggle) =>
         toggle
           .setValue(
             this.plugin.settings
-              .leadingNewLine === undefined || 
-              this.plugin.settings.leadingNewLine === null 
-              ? true 
+              .leadingNewLine === undefined ||
+              this.plugin.settings.leadingNewLine === null
+              ? true
               : this.plugin.settings.leadingNewLine
           )
           .onChange((value) => {
             this.plugin.settings.leadingNewLine = value;
+            this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(this.containerEl)
+      .setName("Ignore todos in blockquotes/callouts")
+      .setDesc(
+        `If enabled, todos inside blockquotes or callouts (lines starting with >) will not be rolled over. This is useful if you have daily habits in a callout that should reset each day instead of being rolled over.`
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.ignoreBlockquotes || false)
+          .onChange((value) => {
+            this.plugin.settings.ignoreBlockquotes = value;
             this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
This PR adds a new optional setting **"Ignore todos in blockquotes/callouts"** that allows users to exclude todos inside blockquote syntax (lines starting with `>`) from being rolled over.

## Problem

Many users use Obsidian callouts for daily habits that should reset each day:

```markdown
> [!tip] Daily Habits
> - [ ] Drink water
> - [ ] Exercise
> - [ ] Read 10 pages
```

Currently, these todos get rolled over like any other todo, which is undesirable for recurring daily habits that should start fresh each day.

## Solution

Added a new toggle setting that, when enabled, ignores any checkbox that appears inside a blockquote (line starts with `>`). This allows users to:
- Keep daily habits in callouts that reset each day
- Still roll over regular todos under `## Tasks` or other headings

## Changes

- `src/get-todos.js`: Added `#ignoreBlockquotes` property and `#isInBlockquote()` method
- `src/index.js`: Added `ignoreBlockquotes` to default settings and passed it to `getTodos()`
- `src/ui/RolloverSettingTab.js`: Added UI toggle for the new setting

## Backward Compatibility

The setting is **disabled by default**, so existing users won't notice any change unless they explicitly enable it.

## Testing

1. Create a daily note with todos in a callout and regular todos
2. Enable "Ignore todos in blockquotes/callouts" in settings
3. Create a new daily note
4. Verify that only regular todos are rolled over, not the ones in callouts