### PR TITLE
Add section-aware rollover for matching headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ By default, the plugin considers checkboxes containing 'x', 'X', or '-' as compl
 
 The plugin supports Unicode characters, including complex emoji and grapheme clusters, in checkbox content. This means you can use emojis or special Unicode characters as status markers and they will be handled correctly.
 
+### 7. Roll over to matching sections
+
+By default, all incomplete todos are collected into a flat list and placed under your chosen template heading (or at the end of the file). Enabling this setting preserves the section structure of your daily note — todos are rolled back into the section they came from.
+
+Headings are matched by text content (case-insensitive), ignoring the heading level. So `# House` in yesterday's note will match `## House` in today's template. A section boundary is defined by the next heading or a `---` separator.
+
+Any todos from sections that don't have a matching heading in today's note will fall back to the end of the file. Duplicate todos that already exist in today's note are skipped.
+
+When this setting is enabled, the "Template heading" setting is bypassed — each section handles its own placement.
+
 ## Bugs/Issues
 
 1. Sometimes you will use this plugin, and your unfinished todos will stay in the same spot. These could be formatting issues.

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -116,6 +116,11 @@ class TodoParser {
     return this.#lines[l].search(/\S/);
   }
 
+  // Returns true if a single line is an unfinished todo (public wrapper around #isTodo)
+  isTodoLine(line) {
+    return this.#isTodo(line);
+  }
+
   // Returns a list of strings that represents all the todos along with there potential children
   getTodos() {
     let todos = [];
@@ -154,6 +159,7 @@ export const getTodosBySection = ({
 }) => {
   const sectionTodos = new Map();
   let currentHeading = "__no_heading__";
+  const todoChecker = new TodoParser([], false, doneStatusMarkers);
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -164,9 +170,7 @@ export const getTodosBySection = ({
     }
 
     // Check if this line is an unfinished todo
-    const todoParser = new TodoParser([line], false, doneStatusMarkers);
-    const parsed = todoParser.getTodos();
-    if (parsed.length > 0) {
+    if (todoChecker.isTodoLine(line)) {
       if (!sectionTodos.has(currentHeading)) {
         sectionTodos.set(currentHeading, []);
       }

--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -143,3 +143,51 @@ export const getTodos = ({
   const todoParser = new TodoParser(lines, withChildren, doneStatusMarkers);
   return todoParser.getTodos();
 };
+
+// Returns unfinished todos grouped by their parent heading.
+// Returns a Map of heading text (lowercase, without # prefix) -> array of todo lines.
+// Todos before any heading use key "__no_heading__".
+export const getTodosBySection = ({
+  lines,
+  withChildren = false,
+  doneStatusMarkers = null,
+}) => {
+  const sectionTodos = new Map();
+  let currentHeading = "__no_heading__";
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const headingMatch = line.match(/^#{1,6}\s+(.*)$/);
+    if (headingMatch) {
+      currentHeading = headingMatch[1].trim().toLowerCase();
+      continue;
+    }
+
+    // Check if this line is an unfinished todo
+    const todoParser = new TodoParser([line], false, doneStatusMarkers);
+    const parsed = todoParser.getTodos();
+    if (parsed.length > 0) {
+      if (!sectionTodos.has(currentHeading)) {
+        sectionTodos.set(currentHeading, []);
+      }
+      sectionTodos.get(currentHeading).push(line);
+
+      // Collect children if enabled
+      if (withChildren) {
+        const parentIndent = line.search(/\S/);
+        let j = i + 1;
+        while (j < lines.length) {
+          const childIndent = lines[j].search(/\S/);
+          if (childIndent > parentIndent && childIndent >= 0) {
+            sectionTodos.get(currentHeading).push(lines[j]);
+            j++;
+          } else {
+            break;
+          }
+        }
+        i = j - 1;
+      }
+    }
+  }
+  return sectionTodos;
+};

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { getTodos } from "./get-todos";
+import { getTodos, getTodosBySection } from "./get-todos";
 
 test("single todo element should return itself", () => {
   // GIVEN
@@ -534,4 +534,120 @@ test("should not match malformed todos", () => {
   ];
   const todos = getTodos({ lines });
   expect(todos).toStrictEqual(["- [ ] valid todo"]);
+});
+
+// --- getTodosBySection tests ---
+
+test("getTodosBySection groups todos by heading", () => {
+  const lines = [
+    "## Routines",
+    "- [ ] brush teeth",
+    "- [x] medication",
+    "## Work",
+    "- [ ] review PR",
+    "- [ ] write docs",
+    "## Personal",
+    "- [x] groceries",
+  ];
+
+  const result = getTodosBySection({ lines });
+
+  expect(result.size).toBe(2);
+  expect(result.get("routines")).toStrictEqual(["- [ ] brush teeth"]);
+  expect(result.get("work")).toStrictEqual([
+    "- [ ] review PR",
+    "- [ ] write docs",
+  ]);
+  expect(result.has("personal")).toBe(false);
+});
+
+test("getTodosBySection puts todos before any heading under __no_heading__", () => {
+  const lines = [
+    "- [ ] orphan task",
+    "## Section",
+    "- [ ] section task",
+  ];
+
+  const result = getTodosBySection({ lines });
+
+  expect(result.get("__no_heading__")).toStrictEqual(["- [ ] orphan task"]);
+  expect(result.get("section")).toStrictEqual(["- [ ] section task"]);
+});
+
+test("getTodosBySection handles different heading levels", () => {
+  const lines = [
+    "# Top Level",
+    "- [ ] task a",
+    "### Deep Level",
+    "- [ ] task b",
+  ];
+
+  const result = getTodosBySection({ lines });
+
+  expect(result.get("top level")).toStrictEqual(["- [ ] task a"]);
+  expect(result.get("deep level")).toStrictEqual(["- [ ] task b"]);
+});
+
+test("getTodosBySection with children enabled", () => {
+  const lines = [
+    "## Dev",
+    "- [ ] main task",
+    "    - subtask detail",
+    "    - another detail",
+    "## Other",
+    "- [ ] other task",
+  ];
+
+  const result = getTodosBySection({ lines, withChildren: true });
+
+  expect(result.get("dev")).toStrictEqual([
+    "- [ ] main task",
+    "    - subtask detail",
+    "    - another detail",
+  ]);
+  expect(result.get("other")).toStrictEqual(["- [ ] other task"]);
+});
+
+test("getTodosBySection skips sections with no unfinished todos", () => {
+  const lines = [
+    "## Done Section",
+    "- [x] completed",
+    "- [x] also done",
+    "## Active Section",
+    "- [ ] still working",
+  ];
+
+  const result = getTodosBySection({ lines });
+
+  expect(result.size).toBe(1);
+  expect(result.has("done section")).toBe(false);
+  expect(result.get("active section")).toStrictEqual(["- [ ] still working"]);
+});
+
+test("getTodosBySection respects custom done status markers", () => {
+  const lines = [
+    "## Section",
+    "- [✅] done with emoji",
+    "- [🟣] in progress",
+    "- [ ] not started",
+  ];
+
+  const result = getTodosBySection({ lines, doneStatusMarkers: "✅" });
+
+  expect(result.get("section")).toStrictEqual([
+    "- [🟣] in progress",
+    "- [ ] not started",
+  ]);
+});
+
+test("getTodosBySection returns empty map when no todos exist", () => {
+  const lines = [
+    "## Section",
+    "Some text",
+    "- [x] all done",
+  ];
+
+  const result = getTodosBySection({ lines });
+
+  expect(result.size).toBe(0);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -280,6 +280,11 @@ export default class RolloverTodosPlugin extends Plugin {
             oldContent: `${dailyNoteContent}`,
           };
 
+          // Build a set of trimmed lines already in today's note to avoid duplicates
+          const existingLines = new Set(
+            dailyNoteContent.split(/\r?\n|\r/g).map((l) => l.trim())
+          );
+
           let unmatchedTodos = [];
 
           for (const [sectionKey, todos] of todosBySection) {
@@ -317,16 +322,32 @@ export default class RolloverTodosPlugin extends Plugin {
             }
 
             if (insertIndex >= 0) {
-              lines.splice(insertIndex, 0, ...todos);
-              dailyNoteContent = lines.join("\n");
+              const newTodos = todos.filter(
+                (t) => !existingLines.has(t.trim())
+              );
+              if (newTodos.length > 0) {
+                lines.splice(insertIndex, 0, ...newTodos);
+                dailyNoteContent = lines.join("\n");
+              }
             } else {
-              unmatchedTodos.push(...todos);
+              unmatchedTodos.push(
+                ...todos.filter((t) => !existingLines.has(t.trim()))
+              );
             }
           }
 
           // Append any unmatched todos to the end of the file
           if (unmatchedTodos.length > 0) {
-            dailyNoteContent += `\n${unmatchedTodos.join("\n")}`;
+            // Re-check against current content since earlier insertions may have added lines
+            const updatedLines = new Set(
+              dailyNoteContent.split(/\r?\n|\r/g).map((l) => l.trim())
+            );
+            const dedupedUnmatched = unmatchedTodos.filter(
+              (t) => !updatedLines.has(t.trim())
+            );
+            if (dedupedUnmatched.length > 0) {
+              dailyNoteContent += `\n${dedupedUnmatched.join("\n")}`;
+            }
           }
 
           await this.app.vault.modify(file, dailyNoteContent);
@@ -356,28 +377,40 @@ export default class RolloverTodosPlugin extends Plugin {
             file: file,
             oldContent: `${dailyNoteContent}`,
           };
-          const todos_todayString = `\n${todos_today.join("\n")}`;
 
-          if (templateHeadingSelected) {
-            const contentAddedToHeading = dailyNoteContent.replace(
-              templateHeading,
-              `${templateHeading}${leadingNewLine ? "\n" : ""}${todos_todayString}`
-            );
-            if (contentAddedToHeading == dailyNoteContent) {
-              templateHeadingNotFoundMessage = `Rollover couldn't find '${templateHeading}' in today's daily note. Rolling todos to end of file.`;
-            } else {
-              dailyNoteContent = contentAddedToHeading;
+          // Filter out todos that already exist in today's note (e.g. from template)
+          const existingLines = new Set(
+            dailyNoteContent.split(/\r?\n|\r/g).map((l) => l.trim())
+          );
+          todos_today = todos_today.filter(
+            (t) => !existingLines.has(t.trim())
+          );
+          todosAdded = todos_today.length;
+
+          if (todos_today.length > 0) {
+            const todos_todayString = `\n${todos_today.join("\n")}`;
+
+            if (templateHeadingSelected) {
+              const contentAddedToHeading = dailyNoteContent.replace(
+                templateHeading,
+                `${templateHeading}${leadingNewLine ? "\n" : ""}${todos_todayString}`
+              );
+              if (contentAddedToHeading == dailyNoteContent) {
+                templateHeadingNotFoundMessage = `Rollover couldn't find '${templateHeading}' in today's daily note. Rolling todos to end of file.`;
+              } else {
+                dailyNoteContent = contentAddedToHeading;
+              }
             }
-          }
 
-          if (
-            !templateHeadingSelected ||
-            templateHeadingNotFoundMessage.length > 0
-          ) {
-            dailyNoteContent += todos_todayString;
-          }
+            if (
+              !templateHeadingSelected ||
+              templateHeadingNotFoundMessage.length > 0
+            ) {
+              dailyNoteContent += todos_todayString;
+            }
 
-          await this.app.vault.modify(file, dailyNoteContent);
+            await this.app.vault.modify(file, dailyNoteContent);
+          }
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export default class RolloverTodosPlugin extends Plugin {
 
   async getAllUnfinishedTodos(file) {
     const dn = await this.app.vault.read(file);
-    const dnLines = dn.split(/\r?\n|\r|\n/g);
+    const dnLines = dn.split(/\r?\n|\r/g);
 
     return getTodos({
       lines: dnLines,
@@ -241,7 +241,7 @@ export default class RolloverTodosPlugin extends Plugin {
       if (rolloverToMatchingSections) {
         // --- Section-aware rollover ---
         const lastDailyNoteContent = await this.app.vault.read(lastDailyNote);
-        const lastDailyNoteLines = lastDailyNoteContent.split(/\r?\n|\r|\n/g);
+        const lastDailyNoteLines = lastDailyNoteContent.split(/\r?\n|\r/g);
 
         const todosBySection = getTodosBySection({
           lines: lastDailyNoteLines,
@@ -289,7 +289,7 @@ export default class RolloverTodosPlugin extends Plugin {
             }
 
             // Find the matching heading in today's note by text content
-            const lines = dailyNoteContent.split("\n");
+            const lines = dailyNoteContent.split(/\r?\n|\r/g);
             let insertIndex = -1;
 
             for (let i = 0; i < lines.length; i++) {
@@ -305,6 +305,11 @@ export default class RolloverTodosPlugin extends Plugin {
                     break;
                   }
                   j++;
+                }
+                // Backtrack past trailing blank lines so todos appear
+                // right after the heading's content, not after template gaps
+                while (j > i + 1 && lines[j - 1].trim() === "") {
+                  j--;
                 }
                 insertIndex = j;
                 break;

--- a/src/index.js
+++ b/src/index.js
@@ -484,25 +484,6 @@ export default class RolloverTodosPlugin extends Plugin {
     this.registerEvent(
       this.app.vault.on("create", async (file) => {
         if (!this.settings.rolloverOnFileCreate) return;
-
-        // wait for template to be applied before rolling over
-        // (timeout fallback if no template is used)
-        const content = await this.app.vault.read(file);
-        if (content.trim() === "") {
-          await new Promise((resolve) => {
-            const modifyRef = this.app.vault.on("modify", (modifiedFile) => {
-              if (modifiedFile.path === file.path) {
-                this.app.vault.offref(modifyRef);
-                resolve();
-              }
-            });
-            setTimeout(() => {
-              this.app.vault.offref(modifyRef);
-              resolve();
-            }, 5000);
-          });
-        }
-
         this.rollover(file);
       })
     );

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {
 } from "obsidian-daily-notes-interface";
 import UndoModal from "./ui/UndoModal";
 import RolloverSettingTab from "./ui/RolloverSettingTab";
-import { getTodos } from "./get-todos";
+import { getTodos, getTodosBySection } from "./get-todos";
 
 const MAX_TIME_SINCE_CREATION = 5000; // 5 seconds
 
@@ -46,6 +46,7 @@ export default class RolloverTodosPlugin extends Plugin {
       removeEmptyTodos: false,
       rolloverChildren: false,
       rolloverOnFileCreate: true,
+      rolloverToMatchingSections: false,
       doneStatusMarkers: "xX-",
       leadingNewLine: true,
     };
@@ -198,15 +199,17 @@ export default class RolloverTodosPlugin extends Plugin {
         10000
       );
     } else {
-      const { templateHeading, deleteOnComplete, removeEmptyTodos, leadingNewLine } =
-        this.settings;
+      const {
+        templateHeading,
+        deleteOnComplete,
+        removeEmptyTodos,
+        rolloverToMatchingSections,
+        leadingNewLine,
+      } = this.settings;
 
       // check if there is a daily note from yesterday
       const lastDailyNote = this.getLastDailyNote();
       if (!lastDailyNote) return;
-
-      // TODO: Rollover to subheadings (optional)
-      //this.sortHeadersIntoHierarchy(lastDailyNote)
 
       // get unfinished todos from yesterday, if exist
       let todos_yesterday = await this.getAllUnfinishedTodos(lastDailyNote);
@@ -231,58 +234,146 @@ export default class RolloverTodosPlugin extends Plugin {
         },
       };
 
-      // Potentially filter todos from yesterday for today
       let todosAdded = 0;
       let emptiesToNotAddToTomorrow = 0;
-      let todos_today = !removeEmptyTodos ? todos_yesterday : [];
-      if (removeEmptyTodos) {
-        todos_yesterday.forEach((line, i) => {
-          const trimmedLine = (line || "").trim();
-          if (trimmedLine != "- [ ]" && trimmedLine != "- [  ]") {
-            todos_today.push(line);
-            todosAdded++;
-          } else {
-            emptiesToNotAddToTomorrow++;
-          }
-        });
-      } else {
-        todosAdded = todos_yesterday.length;
-      }
-
-      // get today's content and modify it
       let templateHeadingNotFoundMessage = "";
-      const templateHeadingSelected = templateHeading !== "none";
 
-      if (todos_today.length > 0) {
-        let dailyNoteContent = await this.app.vault.read(file);
-        undoHistoryInstance.today = {
-          file: file,
-          oldContent: `${dailyNoteContent}`,
-        };
-        const todos_todayString = `\n${todos_today.join("\n")}`;
+      if (rolloverToMatchingSections) {
+        // --- Section-aware rollover ---
+        const lastDailyNoteContent = await this.app.vault.read(lastDailyNote);
+        const lastDailyNoteLines = lastDailyNoteContent.split(/\r?\n|\r|\n/g);
 
-        // If template heading is selected, try to rollover to template heading
-        if (templateHeadingSelected) {
-          const contentAddedToHeading = dailyNoteContent.replace(
-            templateHeading,
-            `${templateHeading}${leadingNewLine ? '\n' : ''}${todos_todayString}`
-          );
-          if (contentAddedToHeading == dailyNoteContent) {
-            templateHeadingNotFoundMessage = `Rollover couldn't find '${templateHeading}' in today's daily not. Rolling todos to end of file.`;
-          } else {
-            dailyNoteContent = contentAddedToHeading;
+        const todosBySection = getTodosBySection({
+          lines: lastDailyNoteLines,
+          withChildren: this.settings.rolloverChildren,
+          doneStatusMarkers: this.settings.doneStatusMarkers,
+        });
+
+        // Filter empty todos if setting is enabled
+        if (removeEmptyTodos) {
+          for (const [heading, todos] of todosBySection) {
+            const filtered = todos.filter((line) => {
+              const trimmedLine = (line || "").trim();
+              if (trimmedLine === "- [ ]" || trimmedLine === "- [  ]") {
+                emptiesToNotAddToTomorrow++;
+                return false;
+              }
+              return true;
+            });
+            if (filtered.length > 0) {
+              todosBySection.set(heading, filtered);
+            } else {
+              todosBySection.delete(heading);
+            }
           }
         }
 
-        // Rollover to bottom of file if no heading found in file, or no heading selected
-        if (
-          !templateHeadingSelected ||
-          templateHeadingNotFoundMessage.length > 0
-        ) {
-          dailyNoteContent += todos_todayString;
+        // Count todos that will actually be added
+        todosBySection.forEach((todos) => {
+          todosAdded += todos.length;
+        });
+
+        if (todosAdded > 0) {
+          let dailyNoteContent = await this.app.vault.read(file);
+          undoHistoryInstance.today = {
+            file: file,
+            oldContent: `${dailyNoteContent}`,
+          };
+
+          let unmatchedTodos = [];
+
+          for (const [sectionKey, todos] of todosBySection) {
+            if (sectionKey === "__no_heading__") {
+              unmatchedTodos.push(...todos);
+              continue;
+            }
+
+            // Find the matching heading in today's note by text content
+            const lines = dailyNoteContent.split("\n");
+            let insertIndex = -1;
+
+            for (let i = 0; i < lines.length; i++) {
+              const lineHeadingMatch = lines[i].match(/^#{1,6}\s+(.*)$/);
+              if (
+                lineHeadingMatch &&
+                lineHeadingMatch[1].trim().toLowerCase() === sectionKey
+              ) {
+                // Found the heading — find the end of its section
+                let j = i + 1;
+                while (j < lines.length) {
+                  if (lines[j].match(/^#{1,6}\s/) || lines[j].trim() === "---") {
+                    break;
+                  }
+                  j++;
+                }
+                insertIndex = j;
+                break;
+              }
+            }
+
+            if (insertIndex >= 0) {
+              lines.splice(insertIndex, 0, ...todos);
+              dailyNoteContent = lines.join("\n");
+            } else {
+              unmatchedTodos.push(...todos);
+            }
+          }
+
+          // Append any unmatched todos to the end of the file
+          if (unmatchedTodos.length > 0) {
+            dailyNoteContent += `\n${unmatchedTodos.join("\n")}`;
+          }
+
+          await this.app.vault.modify(file, dailyNoteContent);
+        }
+      } else {
+        // --- Original single-heading rollover ---
+        let todos_today = !removeEmptyTodos ? todos_yesterday : [];
+        if (removeEmptyTodos) {
+          todos_yesterday.forEach((line, i) => {
+            const trimmedLine = (line || "").trim();
+            if (trimmedLine != "- [ ]" && trimmedLine != "- [  ]") {
+              todos_today.push(line);
+              todosAdded++;
+            } else {
+              emptiesToNotAddToTomorrow++;
+            }
+          });
+        } else {
+          todosAdded = todos_yesterday.length;
         }
 
-        await this.app.vault.modify(file, dailyNoteContent);
+        const templateHeadingSelected = templateHeading !== "none";
+
+        if (todos_today.length > 0) {
+          let dailyNoteContent = await this.app.vault.read(file);
+          undoHistoryInstance.today = {
+            file: file,
+            oldContent: `${dailyNoteContent}`,
+          };
+          const todos_todayString = `\n${todos_today.join("\n")}`;
+
+          if (templateHeadingSelected) {
+            const contentAddedToHeading = dailyNoteContent.replace(
+              templateHeading,
+              `${templateHeading}${leadingNewLine ? "\n" : ""}${todos_todayString}`
+            );
+            if (contentAddedToHeading == dailyNoteContent) {
+              templateHeadingNotFoundMessage = `Rollover couldn't find '${templateHeading}' in today's daily note. Rolling todos to end of file.`;
+            } else {
+              dailyNoteContent = contentAddedToHeading;
+            }
+          }
+
+          if (
+            !templateHeadingSelected ||
+            templateHeadingNotFoundMessage.length > 0
+          ) {
+            dailyNoteContent += todos_todayString;
+          }
+
+          await this.app.vault.modify(file, dailyNoteContent);
+        }
       }
 
       // if deleteOnComplete, get yesterday's content and modify it

--- a/src/index.js
+++ b/src/index.js
@@ -483,8 +483,26 @@ export default class RolloverTodosPlugin extends Plugin {
 
     this.registerEvent(
       this.app.vault.on("create", async (file) => {
-        // Check if automatic daily note creation is enabled
         if (!this.settings.rolloverOnFileCreate) return;
+
+        // wait for template to be applied before rolling over
+        // (timeout fallback if no template is used)
+        const content = await this.app.vault.read(file);
+        if (content.trim() === "") {
+          await new Promise((resolve) => {
+            const modifyRef = this.app.vault.on("modify", (modifiedFile) => {
+              if (modifiedFile.path === file.path) {
+                this.app.vault.offref(modifyRef);
+                resolve();
+              }
+            });
+            setTimeout(() => {
+              this.app.vault.offref(modifyRef);
+              resolve();
+            }, 5000);
+          });
+        }
+
         this.rollover(file);
       })
     );

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -117,6 +117,20 @@ export default class RolloverSettingTab extends PluginSettingTab {
       );
 
     new Setting(this.containerEl)
+      .setName("Roll over to matching sections")
+      .setDesc(
+        `When enabled, todos are rolled over to the matching section in today's note (matched by heading text). When disabled, todos roll to the selected template heading or end of file.`
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.rolloverToMatchingSections || false)
+          .onChange((value) => {
+            this.plugin.settings.rolloverToMatchingSections = value;
+            this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(this.containerEl)
       .setName("Done status markers")
       .setDesc(
         `Characters that represent done status in checkboxes. Default is "xX-". Add any characters that should be considered as marking a task complete.`


### PR DESCRIPTION
## Summary

   Adds a new **"Roll over to matching sections"** setting that rolls unfinished todos back to their corresponding section in today's daily note, rather than dumping them all under a single heading or at the end of the file.

   - Adds `getTodosBySection()` to `get-todos.js` — groups unfinished todos by their parent heading
   - Adds `rolloverToMatchingSections` setting (default `false`) for full backward compatibility
   - When enabled, headings are matched by text content (case-insensitive, ignoring `#` level), so `# House` and `## House` match correctly
   - Section boundaries are defined by the next heading or `---` separator
   - Todos from sections not found in today's note fall back to the end of the file
   - Adds 7 new tests for the section grouping logic

   Closes #143, relates to #68 and #150.