### PR TITLE
Fix: anchor #isTodo regex to start of line

### DIFF
--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -43,7 +43,7 @@ class TodoParser {
   // Returns true if string s is a todo-item
   #isTodo(s) {
     // Extract the checkbox content
-    const match = s.match(/\s*[*+-] \[(.+?)\]/);
+    const match = s.match(/^\s*[*+-] \[(.+?)\]/);
     if (!match) return false;
 
     const checkboxContent = match[1];


### PR DESCRIPTION
## Summary

The `#isTodo` regex in `src/get-todos.js` was unanchored:

```js
// before
const match = s.match(/\s*[*+-] \[(.+?)\]/);
// after
const match = s.match(/^\s*[*+-] \[(.+?)\]/);
```

Without `^`, the regex matches `- [ ]` **anywhere** in a line — including inside template literals in fenced code blocks (e.g. dataviewjs / templater scripts). Combined with `rolloverChildren: true`, this causes lines like:

```
    const md = items.map(t => `- [ ] ${t}`).join("\n");
```

to be treated as todos and rolled over into the next day's note, dragging any more-indented lines along as "children."

`^\s*` is the correct fix:
- `- [ ] Foo` — matches (bullet at col 0) ✓  
- `\t- [ ] Foo` — matches (`\s*` consumes leading tab) ✓  
- `    - [ ] Foo` — matches (`\s*` consumes 4 spaces) ✓  
- `    const md = items.map(t => \`- [ ] ${…}\`)` — rejected (`\s*` consumes spaces, next char is `c` not a bullet) ✓  

## Test plan

- [x] All 19 existing tests pass (`npm test`)
- [x] Fix is one character — adding `^` to the regex in `src/get-todos.js:46`