### PR TITLE
Add option to skip completed todos when rolling over

### DIFF
--- a/src/get-todos.js
+++ b/src/get-todos.js
@@ -40,43 +40,32 @@ class TodoParser {
     }
   }
 
-  // Returns true if string s is a todo-item
-  #isTodo(s) {
-    // Extract the checkbox content
+  // Returns the single status marker of a well-formed checkbox line, or null
+  // if the line is not a valid checkbox todo-item
+  #checkboxMarker(s) {
     const match = s.match(/\s*[*+-] \[(.+?)\]/);
-    if (!match) return false;
+    if (!match) return null;
 
-    const checkboxContent = match[1];
+    const contentChars = this.#parseIntoChars(match[1], "checkbox content");
 
-    // Parse content with segmentation to allow for Unicode grapheme clusters
-    const contentChars = this.#parseIntoChars(
-      checkboxContent,
-      "checkbox content"
-    );
+    // A valid marker is exactly one grapheme cluster and not a bare modifier
+    if (contentChars.length !== 1) return null;
+    const graphemeModifiers = ["\u202E", "\u200B", "\u200C", "\u200D"];
+    if (graphemeModifiers.includes(contentChars[0])) return null;
 
-    // Valid checkbox content must be exactly one grapheme cluster
-    if (contentChars.length !== 1) {
-      return false;
-    }
+    return contentChars[0];
+  }
 
-    const singleChar = contentChars[0];
+  // Returns true if string s is an unfinished todo-item
+  #isTodo(s) {
+    const marker = this.#checkboxMarker(s);
+    return marker !== null && !this.doneStatusMarkers.includes(marker);
+  }
 
-    // Exclude grapheme modifiers that are not valid as standalone content
-    const graphemeModifiers = ['\u202E', '\u200B', '\u200C', '\u200D'];
-    const hasGraphemeModifier = contentChars.some((char) =>
-      graphemeModifiers.includes(char)
-    );
-    if (hasGraphemeModifier) {
-      return false;
-    }
-
-    // Check if the checkbox content contains any characters that are in doneStatusMarkers
-    const hasDoneMarker = contentChars.some((char) =>
-      this.doneStatusMarkers.includes(char)
-    );
-
-    // Return true (is a todo) if it does NOT contain any done markers
-    return !hasDoneMarker;
+  // Returns true if string s is a completed todo-item
+  #isCompletedTodo(s) {
+    const marker = this.#checkboxMarker(s);
+    return marker !== null && this.doneStatusMarkers.includes(marker);
   }
 
   // Returns true if line after line-number `l` is a nested item
@@ -132,6 +121,60 @@ class TodoParser {
     }
     return todos;
   }
+
+  // Returns true if the line at `l` is empty or whitespace-only
+  #isBlank(l) {
+    return this.#getIndentation(l) === -1;
+  }
+
+  // Returns the index one past the last line nested under line `l`. A blank
+  // line is absorbed into the subtree only when a more-indented line follows
+  // it, so a stray blank line cannot detach a completed parent from a nested
+  // open todo. Trailing blank lines are excluded.
+  #getSubtreeEnd(l) {
+    const parentIndentation = this.#getIndentation(l);
+    let lastNested = l;
+    for (let i = l + 1; i < this.#lines.length; i++) {
+      if (this.#isBlank(i)) continue;
+      if (this.#getIndentation(i) <= parentIndentation) break;
+      lastNested = i;
+    }
+    return lastNested + 1;
+  }
+
+  #subtreeHasOpenTodo(start, end) {
+    for (let i = start; i < end; i++) {
+      if (this.#isTodo(this.#lines[i])) return true;
+    }
+    return false;
+  }
+
+  // Returns the lines with every completed todo-subtree that has no remaining
+  // open todo removed. A completed todo with an open descendant is kept so the
+  // open item retains its context, while fully-completed branches beneath it
+  // are still pruned.
+  getLinesWithCompletedTodosPruned() {
+    const keep = new Array(this.#lines.length).fill(true);
+
+    for (let l = 0; l < this.#lines.length; ) {
+      if (!this.#isCompletedTodo(this.#lines[l])) {
+        l++;
+        continue;
+      }
+
+      const end = this.#getSubtreeEnd(l);
+      if (this.#subtreeHasOpenTodo(l + 1, end)) {
+        // Descend into the subtree to prune its fully-completed branches
+        l++;
+        continue;
+      }
+
+      for (let i = l; i < end; i++) keep[i] = false;
+      l = end;
+    }
+
+    return this.#lines.filter((_, i) => keep[i]);
+  }
 }
 
 // Utility-function that acts as a thin wrapper around `TodoParser`
@@ -142,4 +185,10 @@ export const getTodos = ({
 }) => {
   const todoParser = new TodoParser(lines, withChildren, doneStatusMarkers);
   return todoParser.getTodos();
+};
+
+// Utility-function that removes completed todo-subtrees with no open todo left
+export const pruneCompletedTodos = ({ lines, doneStatusMarkers = null }) => {
+  const todoParser = new TodoParser(lines, false, doneStatusMarkers);
+  return todoParser.getLinesWithCompletedTodosPruned();
 };

--- a/src/get-todos.test.js
+++ b/src/get-todos.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { getTodos } from "./get-todos";
+import { getTodos, pruneCompletedTodos } from "./get-todos";
 
 test("single todo element should return itself", () => {
   // GIVEN
@@ -514,6 +514,200 @@ test("get todos supports custom status marker edge cases (inclusion)", () => {
     "- [é] Simple accented character 2",
   ];
   expect(todos).toStrictEqual(result);
+});
+
+test("prune removes a standalone completed todo", () => {
+  // GIVEN
+  const lines = ["- [ ] open", "- [x] done"];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual(["- [ ] open"]);
+});
+
+test("prune keeps open todos and non-todo lines untouched", () => {
+  // GIVEN
+  const lines = [
+    "# To Dos",
+    "",
+    "- [ ] open",
+    "- [x] done",
+    "Some note",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual(["# To Dos", "", "- [ ] open", "Some note"]);
+});
+
+test("prune removes a completed parent whose children are all completed", () => {
+  // GIVEN
+  const lines = [
+    "- [x] done parent",
+    "    - [x] done child",
+    "    - some note under it",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual([]);
+});
+
+test("prune keeps a completed parent that has an open child", () => {
+  // GIVEN
+  const lines = [
+    "- [x] done parent",
+    "    - [ ] open child",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual([
+    "- [x] done parent",
+    "    - [ ] open child",
+  ]);
+});
+
+test("prune keeps a completed parent with an open child but prunes its completed siblings", () => {
+  // GIVEN
+  const lines = [
+    "- [x] done parent",
+    "    - [ ] open child",
+    "    - [x] done child (no open descendant)",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual([
+    "- [x] done parent",
+    "    - [ ] open child",
+  ]);
+});
+
+test("prune keeps ancestors of a deeply nested open todo", () => {
+  // GIVEN
+  const lines = [
+    "- [x] grandparent",
+    "    - [x] parent",
+    "        - [ ] deeply nested open",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual([
+    "- [x] grandparent",
+    "    - [x] parent",
+    "        - [ ] deeply nested open",
+  ]);
+});
+
+test("prune respects custom done status markers", () => {
+  // GIVEN
+  const lines = [
+    "- [C] custom done",
+    "- [x] not done under custom markers",
+    "- [ ] open",
+  ];
+
+  // WHEN - only 'C' counts as done
+  const result = pruneCompletedTodos({ lines, doneStatusMarkers: "C" });
+
+  // THEN
+  expect(result).toStrictEqual([
+    "- [x] not done under custom markers",
+    "- [ ] open",
+  ]);
+});
+
+test("prune keeps a completed parent when a blank line separates it from an open child", () => {
+  // GIVEN - a stray blank line sits between the parent and its open child
+  const lines = [
+    "- [x] done parent",
+    "    - [x] done leaf",
+    "",
+    "    - [ ] open child",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN - the parent is preserved (not orphaned by the blank line) and the
+  // open child stays; the fully-done leaf is still pruned
+  expect(result).toStrictEqual([
+    "- [x] done parent",
+    "",
+    "    - [ ] open child",
+  ]);
+});
+
+test("prune still removes a fully-completed subtree that contains blank lines", () => {
+  // GIVEN
+  const lines = [
+    "- [x] done parent",
+    "    - [x] done child",
+    "",
+    "    - [x] another done child",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN - whole subtree (including the absorbed blank line) is removed
+  expect(result).toStrictEqual([]);
+});
+
+test("prune does not absorb a blank line between two sibling todos", () => {
+  // GIVEN - blank line separates same-indent todos; not a parent/child relation
+  const lines = [
+    "- [x] done sibling",
+    "",
+    "- [ ] open sibling",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN - only the done sibling is removed; blank line and open sibling stay
+  expect(result).toStrictEqual(["", "- [ ] open sibling"]);
+});
+
+test("prune excludes trailing blank lines after a removed subtree", () => {
+  // GIVEN
+  const lines = [
+    "- [x] done parent",
+    "    - [x] done child",
+    "",
+    "# Next heading",
+  ];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN - trailing blank line and heading are preserved
+  expect(result).toStrictEqual(["", "# Next heading"]);
+});
+
+test("prune leaves a note with only open todos unchanged", () => {
+  // GIVEN
+  const lines = ["- [ ] a", "    - [ ] b", "- [ ] c"];
+
+  // WHEN
+  const result = pruneCompletedTodos({ lines });
+
+  // THEN
+  expect(result).toStrictEqual(lines);
 });
 
 test("should not match malformed todos", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {
 } from "obsidian-daily-notes-interface";
 import UndoModal from "./ui/UndoModal";
 import RolloverSettingTab from "./ui/RolloverSettingTab";
-import { getTodos } from "./get-todos";
+import { getTodos, pruneCompletedTodos } from "./get-todos";
 
 const MAX_TIME_SINCE_CREATION = 5000; // 5 seconds
 
@@ -48,6 +48,7 @@ export default class RolloverTodosPlugin extends Plugin {
       rolloverOnFileCreate: true,
       doneStatusMarkers: "xX-",
       leadingNewLine: true,
+      removeCompletedTodos: false,
     };
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }
@@ -198,8 +199,13 @@ export default class RolloverTodosPlugin extends Plugin {
         10000
       );
     } else {
-      const { templateHeading, deleteOnComplete, removeEmptyTodos, leadingNewLine } =
-        this.settings;
+      const {
+        templateHeading,
+        deleteOnComplete,
+        removeEmptyTodos,
+        leadingNewLine,
+        removeCompletedTodos: removeCompletedTodosSetting,
+      } = this.settings;
 
       // check if there is a daily note from yesterday
       const lastDailyNote = this.getLastDailyNote();
@@ -247,6 +253,16 @@ export default class RolloverTodosPlugin extends Plugin {
         });
       } else {
         todosAdded = todos_yesterday.length;
+      }
+
+      // drop completed todos that have no unfinished sub-todo, so today only
+      // carries open work (and the completed parents needed to keep it nested)
+      if (removeCompletedTodosSetting) {
+        todos_today = pruneCompletedTodos({
+          lines: todos_today,
+          doneStatusMarkers: this.settings.doneStatusMarkers,
+        });
+        todosAdded = todos_today.length;
       }
 
       // get today's content and modify it

--- a/src/ui/RolloverSettingTab.js
+++ b/src/ui/RolloverSettingTab.js
@@ -67,6 +67,20 @@ export default class RolloverSettingTab extends PluginSettingTab {
       );
 
     new Setting(this.containerEl)
+      .setName("Remove completed todos when rolling over")
+      .setDesc(
+        `Skip completed todos so they are not carried into today's note. A completed todo that still has an unfinished (open) sub-todo is kept so the open item retains its context. Only affects completed todos pulled in via "Roll over children of todos"; previous notes are left untouched.`
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.removeCompletedTodos || false)
+          .onChange((value) => {
+            this.plugin.settings.removeCompletedTodos = value;
+            this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(this.containerEl)
       .setName("Remove empty todos in rollover")
       .setDesc(
         `If you have empty todos, they will not be rolled over to the next day.`


### PR DESCRIPTION
Closes #174.

## Summary

Adds an opt-in **"Remove completed todos when rolling over"** setting. When enabled, completed todos are dropped from the set carried into today's note, so it only keeps open work. A completed todo is kept when its subtree still contains an unfinished todo, so the open item retains its context; fully-completed branches are dropped.

The setting:
- defaults to **off**;
- is **non-destructive** — only the todos written into today are affected; previous notes are not modified;
- honors the existing **Done status markers** setting;
- only has an effect alongside **"Roll over children of todos"** (the only path by which completed items roll forward).

## Motivation

With "Roll over children of todos" on, rolling an open parent forward copies its whole subtree, including completed `[x]` descendants, which then clutter today's note. This drops those completed items while preserving any still-open work and the completed parents needed to keep it nested.

## Behavior

Given this in the previous note (open parent rolls forward with children):

```md
- [ ] Project
    - [ ] Review
    - [x] Deploy
        - [x] Run pipeline
```

today's note receives:

```md
- [ ] Project
    - [ ] Review
```

| Rolled-over item | Result in today |
| --- | --- |
| `- [x] done` under an open parent | dropped |
| `- [x] parent` / `    - [x] child` | whole branch dropped |
| `- [x] parent` / `    - [ ] child` | kept |
| `- [x] parent` / `    - [ ] open` / `    - [x] done` | parent + open kept, done sibling dropped |
| `- [x] parent` / blank line / `    - [ ] open` | parent kept (blank line does not detach the open child) |

## How this differs from existing settings and requests

- **Existing "Delete todos from previous day" (`deleteOnComplete`)** removes the **unfinished** todos copied to today *from the previous note* (dedup). This PR affects **what is carried into today** and leaves previous notes untouched. The two are independent.
- **#141** (backup/undo for that setting), **#153** (mark rolled todos complete), and **#125** (keep completed nested todos visible) are each a different operation, target, or the inverse desire.

## Implementation

- `get-todos.js`: factored checkbox parsing into a shared `#checkboxMarker`, added completed-todo detection and `getLinesWithCompletedTodosPruned()`, and exported `pruneCompletedTodos`. The existing `getTodos` / `rolloverChildren` path is unchanged.
- `index.js`: new `removeCompletedTodos` setting; when on, the rolled-over todos are passed through `pruneCompletedTodos` before being written to today.
- `RolloverSettingTab.js`: new toggle.

## Test plan

- [x] `npm test` — 31 passing (12 new cases: standalone, nested, sibling pruning, deep nesting, custom markers, and the blank-line cases).
- [x] `npm run build` succeeds.
- [x] Verified the full rollover pipeline on a real nested note: an open parent's completed children are dropped from today while open children and completed parents of open work are kept.